### PR TITLE
FF3V: Use unsigned 32bit for gain compensation multiplier

### DIFF
--- a/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.h
+++ b/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.h
@@ -14,7 +14,7 @@
 #define SRC_FF3V_FIR_TAPS_PER_PHASE (24)
 
 extern const unsigned src_ff3v_fir_comp_q;
-extern const int32_t src_ff3v_fir_comp;
+extern const uint32_t src_ff3v_fir_comp;
 
 extern int32_t src_ff3v_fir_coefs_debug[SRC_FF3V_FIR_NUM_PHASES * SRC_FF3V_FIR_TAPS_PER_PHASE];
 extern const int32_t src_ff3v_fir_coefs[SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_PHASE];

--- a/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.xc
+++ b/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.xc
@@ -12,7 +12,7 @@
 const unsigned src_ff3v_fir_comp_q = 30;
 
 /** Used for FIR compensation */
-const int32_t src_ff3v_fir_comp = 2225098336;
+const uint32_t src_ff3v_fir_comp = 2225098336;
 
 /** Used for self testing src_ds3_voice and src_us3_voice functionality */
 int32_t src_ff3v_fir_coefs_debug[SRC_FF3V_FIR_NUM_PHASES * SRC_FF3V_FIR_TAPS_PER_PHASE] = {

--- a/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir_generator.py
+++ b/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir_generator.py
@@ -42,7 +42,7 @@ def generate_header_file(num_taps_per_phase, num_phases):
 #define SRC_FF3V_FIR_TAPS_PER_PHASE (%(taps_per_phase)s)
 
 extern const unsigned src_ff3v_fir_comp_q;
-extern const int32_t src_ff3v_fir_comp;
+extern const uint32_t src_ff3v_fir_comp;
 
 extern int32_t src_ff3v_fir_coefs_debug[SRC_FF3V_FIR_NUM_PHASES * SRC_FF3V_FIR_TAPS_PER_PHASE];
 extern const int32_t src_ff3v_fir_coefs[SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_PHASE];

--- a/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir_generator.py
+++ b/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir_generator.py
@@ -71,7 +71,7 @@ def generate_xc_file(q, pass_band_atten, taps):
 const unsigned src_ff3v_fir_comp_q = %(comp_q)s;
 
 /** Used for FIR compensation */
-const int32_t src_ff3v_fir_comp = %(comp)s;
+const uint32_t src_ff3v_fir_comp = %(comp)s;
 
 /** Used for self testing src_ds3_voice and src_us3_voice functionality */
 int32_t src_ff3v_fir_coefs_debug[SRC_FF3V_FIR_NUM_PHASES * SRC_FF3V_FIR_TAPS_PER_PHASE] = {


### PR DESCRIPTION
Rather than signed, so there is more space. It's 2225098336 at the moment, which overflows int32_t.