### PR TITLE
Add proper export of maxchanends and fix a couple of typos

### DIFF
--- a/lib_src/src/multirate_hifi/src_mrhf_adfir_inner_loop_asm.S
+++ b/lib_src/src/multirate_hifi/src_mrhf_adfir_inner_loop_asm.S
@@ -120,6 +120,7 @@ done:
     .set    src_mrhf_adfir_inner_loop_asm.maxtimers,0
     .globl    src_mrhf_adfir_inner_loop_asm.maxtimers
     .set    src_mrhf_adfir_inner_loop_asm.maxchanends,0
+    .globl    src_mrhf_adfir_inner_loop_asm.maxchanends
 
 
 // Odd data alignment (4byte odd instead of 8byte) version
@@ -237,7 +238,7 @@ done_odd:
   retsp stack_size
 
 .atmp_odd:
-    .size    src_mrhf_adfir_inner_loop_asm_odd, .atmp-src_mrhf_adfir_inner_loop_asm_odd
+    .size    src_mrhf_adfir_inner_loop_asm_odd, .atmp_odd-src_mrhf_adfir_inner_loop_asm_odd
     .align    8
     .cc_bottom src_mrhf_adfir_inner_loop_asm_odd.function
 
@@ -248,4 +249,4 @@ done_odd:
     .set    src_mrhf_adfir_inner_loop_asm_odd.maxtimers,0
     .globl    src_mrhf_adfir_inner_loop_asm_odd.maxtimers
     .set    src_mrhf_adfir_inner_loop_asm_odd.maxchanends,0
-
+    .globl    src_mrhf_adfir_inner_loop_asm_odd.maxchanends

--- a/lib_src/src/multirate_hifi/src_mrhf_dither_maths_asm.S
+++ b/lib_src/src/multirate_hifi/src_mrhf_dither_maths_asm.S
@@ -66,7 +66,7 @@ dither_maths_asm:
     .set    dither_maths_asm.maxtimers,0
     .globl    dither_maths_asm.maxtimers
     .set    dither_maths_asm.maxchanends,0
-    .globl     .maxchanends
+    .globl     dither_maths_asm.maxchanends
 
 
 

--- a/lib_src/src/multirate_hifi/src_mrhf_fir_inner_loop_asm.S
+++ b/lib_src/src/multirate_hifi/src_mrhf_fir_inner_loop_asm.S
@@ -120,10 +120,10 @@ done:
     .set    src_mrhf_fir_inner_loop_asm.maxtimers,0
     .globl    src_mrhf_fir_inner_loop_asm.maxtimers
     .set    src_mrhf_fir_inner_loop_asm.maxchanends,0
-    .globl     .maxchanends
+    .globl     src_mrhf_fir_inner_loop_asm.maxchanends
 
 
-        .section    .dp.data,"awd",@progbits
+    .section    .dp.data,"awd",@progbits
     .text
 
     .cc_top src_mrhf_fir_inner_loop_asm_odd.function
@@ -236,7 +236,7 @@ done_odd:
   retsp stack_size
 
 .atmp_odd:
-    .size    src_mrhf_fir_inner_loop_asm_odd, .atmp-src_mrhf_fir_inner_loop_asm_odd
+    .size    src_mrhf_fir_inner_loop_asm_odd, .atmp_odd-src_mrhf_fir_inner_loop_asm_odd
     .align    8
     .cc_bottom src_mrhf_fir_inner_loop_asm_odd.function
 
@@ -247,4 +247,4 @@ done_odd:
     .set    src_mrhf_fir_inner_loop_asm_odd.maxtimers,0
     .globl    src_mrhf_fir_inner_loop_asm_odd.maxtimers
     .set    src_mrhf_fir_inner_loop_asm_odd.maxchanends,0
-    .globl     .maxchanends
+    .globl     src_mrhf_fir_inner_loop_asm_odd.maxchanends

--- a/lib_src/src/multirate_hifi/src_mrhf_fir_os_inner_loop_asm.S
+++ b/lib_src/src/multirate_hifi/src_mrhf_fir_os_inner_loop_asm.S
@@ -123,7 +123,7 @@ done:
     .set    src_mrhf_fir_os_inner_loop_asm.maxtimers,0
     .globl    src_mrhf_fir_os_inner_loop_asm.maxtimers
     .set    src_mrhf_fir_os_inner_loop_asm.maxchanends,0
-    .globl     .maxchanends
+    .globl     src_mrhf_fir_os_inner_loop_asm.maxchanends
 
 
 
@@ -248,7 +248,7 @@ done_odd:
   retsp stack_size
 
 .atmp_odd:
-    .size    src_mrhf_fir_os_inner_loop_asm_odd, .atmp-src_mrhf_fir_os_inner_loop_asm_odd
+    .size    src_mrhf_fir_os_inner_loop_asm_odd, .atmp_odd-src_mrhf_fir_os_inner_loop_asm_odd
     .align    8
     .cc_bottom src_mrhf_fir_os_inner_loop_asm_odd.function
 
@@ -259,6 +259,6 @@ done_odd:
     .set    src_mrhf_fir_os_inner_loop_asm_odd.maxtimers,0
     .globl    src_mrhf_fir_os_inner_loop_asm_odd.maxtimers
     .set    src_mrhf_fir_os_inner_loop_asm_odd.maxchanends,0
-    .globl     .maxchanends
+    .globl     src_mrhf_fir_os_inner_loop_asm_odd.maxchanends
 
 

--- a/lib_src/src/multirate_hifi/src_mrhf_spline_coeff_gen_inner_loop_asm.S
+++ b/lib_src/src/multirate_hifi/src_mrhf_spline_coeff_gen_inner_loop_asm.S
@@ -227,4 +227,4 @@ done:
     .set    src_mrhf_spline_coeff_gen_inner_loop_asm.maxtimers,0
     .globl    src_mrhf_spline_coeff_gen_inner_loop_asm.maxtimers
     .set    src_mrhf_spline_coeff_gen_inner_loop_asm.maxchanends,0
-
+    .globl     src_mrhf_spline_coeff_gen_inner_loop_asm.maxchanends


### PR DESCRIPTION
Fixes the sketchy resource report:

Constraint check for tile[1]:
  Cores available:            8,   used:          7 .  OKAY
  Timers available:          10,   used:          9 .  OKAY
  Chanends available:        32,   used:         22+.  **MAYBE**
  Memory available:       262144,   used:      69096 .  OKAY
    (Stack: 13588, Code: 26848, Data: 28660)
