### PR TITLE
Add braces to initialisation list to avoid warnings when building

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ lib_src change log
 
   * RESOLVED: correct compensation factor for voice upsampling
   * ADDED: test of voice unity gain
+  * CHANGED: initialisation lists to avoid warnings when building
 
 1.1.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,16 @@
 lib_src change log
 ==================
 
+1.1.2
+-----
+
+  * CHANGED: initialisation lists to avoid warnings when building
+
 1.1.1
 -----
 
   * RESOLVED: correct compensation factor for voice upsampling
   * ADDED: test of voice unity gain
-  * CHANGED: initialisation lists to avoid warnings when building
 
 1.1.0
 -----

--- a/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
+++ b/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
@@ -119,57 +119,57 @@ ASRCFiltersIDs_t        sASRCFiltersIDs[ASRC_N_FS][ASRC_N_FS] =                /
 {
     {    // Fsin = 44.1kHz
         // F1                            F2
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 44.1kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 48kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 88.2kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 96kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 176.4kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}        // Fsout = 192kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 44.1kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 48kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 88.2kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 96kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}}         // Fsout = 192kHz
     },
     {    // Fsin = 48kHz
         // F1                            F2
-        {FILTER_DEFS_ASRC_FIR_UP4844_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 44.1kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 48kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 88.2kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 96kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 176.4kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}        // Fsout = 192kHz
+        {{FILTER_DEFS_ASRC_FIR_UP4844_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 44.1kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 48kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 88.2kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 96kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}}         // Fsout = 192kHz
     },
     {    // Fsin = 88.2kHz
         // F1                            F2
-        {FILTER_DEFS_ASRC_FIR_BL_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 44.1kHz
-        {FILTER_DEFS_ASRC_FIR_BL8848_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 48kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 88.2kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 96kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 176.4kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}        // Fsout = 192kHz
+        {{FILTER_DEFS_ASRC_FIR_BL_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 44.1kHz
+        {{FILTER_DEFS_ASRC_FIR_BL8848_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 48kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 88.2kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 96kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}}         // Fsout = 192kHz
     },
     {    // Fsin = 96kHz
         // F1                            F2
-        {FILTER_DEFS_ASRC_FIR_BL9644_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 44.1kHz
-        {FILTER_DEFS_ASRC_FIR_BL_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 48kHz
-        {FILTER_DEFS_ASRC_FIR_UP4844_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 88.2kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 96kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 176.4kHz
-        {FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}        // Fsout = 192kHz
+        {{FILTER_DEFS_ASRC_FIR_BL9644_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 44.1kHz
+        {{FILTER_DEFS_ASRC_FIR_BL_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 48kHz
+        {{FILTER_DEFS_ASRC_FIR_UP4844_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 88.2kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 96kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_ASRC_FIR_UP_ID,            FILTER_DEFS_ASRC_FIR_NONE_ID}}         // Fsout = 192kHz
     },
     {    // Fsin = 176.4kHz
         // F1                            F2
-        {FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL_ID},            // Fsout = 44.1kHz
-        {FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL8848_ID},        // Fsout = 48kHz
-        {FITLER_DEFS_ASRC_FIR_BLF_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID,},        // Fsout = 88.2kHz
-        {FILTER_DEFS_ASRC_FIR_BL17696_ID,    FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 96kHz
-        {FILTER_DEFS_ASRC_FIR_UPF_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 176.4kHz
-        {FILTER_DEFS_ASRC_FIR_UPF_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID}        // Fsout = 192kHz
+        {{FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL_ID}},          // Fsout = 44.1kHz
+        {{FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL8848_ID}},      // Fsout = 48kHz
+        {{FITLER_DEFS_ASRC_FIR_BLF_ID,           FILTER_DEFS_ASRC_FIR_NONE_ID,}},       // Fsout = 88.2kHz
+        {{FILTER_DEFS_ASRC_FIR_BL17696_ID,       FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 96kHz
+        {{FILTER_DEFS_ASRC_FIR_UPF_ID,           FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_ASRC_FIR_UPF_ID,           FILTER_DEFS_ASRC_FIR_NONE_ID}}         // Fsout = 192kHz
     },
     {    // Fsin = 192kHz
         // F1                            F2
-        {FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL9644_ID},        // Fsout = 44.1kHz
-        {FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL_ID},            // Fsout = 48kHz
-        {FITLER_DEFS_ASRC_FIR_BL19288_ID,    FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 88.2kHz
-        {FITLER_DEFS_ASRC_FIR_BLF_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 96kHz
-        {FILTER_DEFS_ASRC_FIR_UP192176_ID,    FILTER_DEFS_ASRC_FIR_NONE_ID},        // Fsout = 176.4kHz
-        {FILTER_DEFS_ASRC_FIR_UPF_ID,        FILTER_DEFS_ASRC_FIR_NONE_ID}        // Fsout = 192kHz
+        {{FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL9644_ID}},      // Fsout = 44.1kHz
+        {{FILTER_DEFS_ASRC_FIR_DS_ID,            FILTER_DEFS_ASRC_FIR_BL_ID}},          // Fsout = 48kHz
+        {{FITLER_DEFS_ASRC_FIR_BL19288_ID,       FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 88.2kHz
+        {{FITLER_DEFS_ASRC_FIR_BLF_ID,           FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 96kHz
+        {{FILTER_DEFS_ASRC_FIR_UP192176_ID,      FILTER_DEFS_ASRC_FIR_NONE_ID}},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_ASRC_FIR_UPF_ID,           FILTER_DEFS_ASRC_FIR_NONE_ID}}         // Fsout = 192kHz
     }
 };
 

--- a/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
+++ b/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
@@ -67,59 +67,58 @@
 SSRCFiltersIDs_t        sFiltersIDs[SSRC_N_FS][SSRC_N_FS] =                // Filter configuration table [Fsin][Fsout]
 {
     {    // Fsin = 44.1kHz
-        // F1                            F2                                F3                                Phase step
-        {FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 44.1kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_294},        // Fsout = 48kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 88.2kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_147},        // Fsout = 96kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_OS_ID,            FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 176.4kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_OS_ID,            FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_147}        // Fsout = 192kHz
+        // F1                                  F2                                   F3                                Phase step
+        {{FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 44.1kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_294},      // Fsout = 48kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 88.2kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_147},      // Fsout = 96kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_OS_ID,          FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_OS_ID,          FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_147}       // Fsout = 192kHz
     },
     {    // Fsin = 48kHz
-        // F1                            F2                                F3                                Phase step
-        {FILTER_DEFS_SSRC_FIR_UP4844_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_320},        // Fsout = 44.1kHz
-        {FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 48kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_160},        // Fsout = 88.2kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 96kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_OS_ID,            FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_160},        // Fsout = 176.4kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_OS_ID,            FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0}            // Fsout = 192kHz
+        // F1                                  F2                                   F3                                Phase step
+        {{FILTER_DEFS_SSRC_FIR_UP4844_ID,      FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_320},      // Fsout = 44.1kHz
+        {{FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 48kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_160},      // Fsout = 88.2kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 96kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_OS_ID,          FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_160},      // Fsout = 176.4kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_OS_ID,          FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0}         // Fsout = 192kHz
     },
     {    // Fsin = 88.2kHz
-        // F1                            F2                                F3                                Phase step
-        {FILTER_DEFS_SSRC_FIR_BL_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 44.1kHz
-        {FILTER_DEFS_SSRC_FIR_BL8848_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_294},        // Fsout = 48kHz
-        {FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 88.2kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_294},        // Fsout = 96kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 176.4kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_147}        // Fsout = 192kHz
+        // F1                                  F2                                   F3                                Phase step
+        {{FILTER_DEFS_SSRC_FIR_BL_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 44.1kHz
+        {{FILTER_DEFS_SSRC_FIR_BL8848_ID,      FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_294},      // Fsout = 48kHz
+        {{FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 88.2kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_294},      // Fsout = 96kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 176.4kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_147}       // Fsout = 192kHz
     },
     {    // Fsin = 96kHz
-        // F1                            F2                                F3                                Phase step
-        {FILTER_DEFS_SSRC_FIR_BL9644_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_320},        // Fsout = 44.1kHz
-        {FILTER_DEFS_SSRC_FIR_BL_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 48kHz
-        {FILTER_DEFS_SSRC_FIR_UP4844_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_320},        // Fsout = 88.2kHz
-        {FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 96kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_160},        // Fsout = 176.4kHz
-        {FILTER_DEFS_SSRC_FIR_UP_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0}            // Fsout = 192kHz
+        // F1                                  F2                                   F3                                Phase step
+        {{FILTER_DEFS_SSRC_FIR_BL9644_ID,      FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_320},      // Fsout = 44.1kHz
+        {{FILTER_DEFS_SSRC_FIR_BL_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 48kHz
+        {{FILTER_DEFS_SSRC_FIR_UP4844_ID,      FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_320},      // Fsout = 88.2kHz
+        {{FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 96kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_160},      // Fsout = 176.4kHz
+        {{FILTER_DEFS_SSRC_FIR_UP_ID,          FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0}         // Fsout = 192kHz
     },
     {    // Fsin = 176.4kHz
-        // F1                            F2                                F3                                Phase step
-        {FILTER_DEFS_SSRC_FIR_DS_ID,            FILTER_DEFS_SSRC_FIR_BL_ID,            FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 44.1kHz
-        {FILTER_DEFS_SSRC_FIR_DS_ID,            FILTER_DEFS_SSRC_FIR_BL8848_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_294},        // Fsout = 48kHz
-        {FILTER_DEFS_SSRC_FIR_BL_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 88.2kHz
-        {FILTER_DEFS_SSRC_FIR_BL17696_ID,    FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_294},        // Fsout = 96kHz
-        {FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 176.4kHz
-        {FILTER_DEFS_SSRC_FIR_UPF_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_294}        // Fsout = 192kHz
+        // F1                                 F2                                   F3                                Phase step
+        {{FILTER_DEFS_SSRC_FIR_DS_ID,         FILTER_DEFS_SSRC_FIR_BL_ID,          FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},         // Fsout = 44.1kHz
+        {{FILTER_DEFS_SSRC_FIR_DS_ID,         FILTER_DEFS_SSRC_FIR_BL8848_ID,      FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_294},       // Fsout = 48kHz
+        {{FILTER_DEFS_SSRC_FIR_BL_ID,         FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},         // Fsout = 88.2kHz
+        {{FILTER_DEFS_SSRC_FIR_BL17696_ID,    FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_294},       // Fsout = 96kHz
+        {{FILTER_DEFS_SSRC_FIR_NONE_ID,       FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},         // Fsout = 176.4kHz
+        {{FILTER_DEFS_SSRC_FIR_UPF_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS320_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_294}        // Fsout = 192kHz
     },
     {    // Fsin = 192kHz
-        // F1                            F2                                F3                                Phase step
-        {FILTER_DEFS_SSRC_FIR_DS_ID,            FILTER_DEFS_SSRC_FIR_BL9644_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_320},        // Fsout = 44.1kHz
-        {FILTER_DEFS_SSRC_FIR_DS_ID,            FILTER_DEFS_SSRC_FIR_BL_ID,            FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 48kHz
-        {FITLER_DEFS_SSRC_FIR_BL19288_ID,    FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_320},        // Fsout = 88.2kHz
-
-        {FILTER_DEFS_SSRC_FIR_BL_ID,            FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0},        // Fsout = 96kHz
-        {FILTER_DEFS_SSRC_FIR_UP192176_ID,    FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_320},        // Fsout = 176.4kHz
-        {FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID,        FILTER_DEFS_PPFIR_PHASE_STEP_0}            // Fsout = 192kHz
+        // F1                                 F2                                   F3                                Phase step
+        {{FILTER_DEFS_SSRC_FIR_DS_ID,         FILTER_DEFS_SSRC_FIR_BL9644_ID,      FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_320},       // Fsout = 44.1kHz
+        {{FILTER_DEFS_SSRC_FIR_DS_ID,         FILTER_DEFS_SSRC_FIR_BL_ID,          FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},         // Fsout = 48kHz
+        {{FITLER_DEFS_SSRC_FIR_BL19288_ID,    FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_320},       // Fsout = 88.2kHz
+        {{FILTER_DEFS_SSRC_FIR_BL_ID,         FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0},         // Fsout = 96kHz
+        {{FILTER_DEFS_SSRC_FIR_UP192176_ID,   FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_HS294_ID},       FILTER_DEFS_PPFIR_PHASE_STEP_320},       // Fsout = 176.4kHz
+        {{FILTER_DEFS_SSRC_FIR_NONE_ID,       FILTER_DEFS_SSRC_FIR_NONE_ID,        FILTER_DEFS_PPFIR_NONE_ID},        FILTER_DEFS_PPFIR_PHASE_STEP_0}          // Fsout = 192kHz
     }
 };
 


### PR DESCRIPTION
The `ASRCFiltersIDs_t` and `SSRCFiltersIDs_t` types each contain an array.  The initialisation lists for variables either of these types did not take that additional array into account when grouping initial values with braces, leading to compiler warnings when building.  This pull request adds in the missing braces.