### PR TITLE
Add missing device attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ lib_src change log
   * CHANGED: Aligned the FIR coefficient array to an 8-byte boundary. This
     ensures that the voice fixed factor of 3 up and down sampling functions do
     not crash with a LOAD_STORE exception.
+  * ADDED: Missing device attributes to the .xn file of the AN00231 app note.
 
 2.1.0
 -----

--- a/examples/AN00231_ASRC_SPDIF_TO_DAC/src/xk-audio-216-mc.xn
+++ b/examples/AN00231_ASRC_SPDIF_TO_DAC/src/xk-audio-216-mc.xn
@@ -85,8 +85,10 @@
   <ExternalDevices>
     <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
-      <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
-      <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
+      <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK"/>
+      <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO"/>
+      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
+      <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/>
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/examples/AN00231_ASRC_SPDIF_TO_DAC/src/xk-audio-216-mc.xn
+++ b/examples/AN00231_ASRC_SPDIF_TO_DAC/src/xk-audio-216-mc.xn
@@ -83,7 +83,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>


### PR DESCRIPTION
Specifically, add the missing `PageSize`, `SectorSize` and `NumPages` attributes.  The AN00231 app note will not build using Tools 15.1.4 without these attributes present.