### PR TITLE
copied CMakeLists.txt from sln_voice and tidied

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ lib_src change log
     ensures that the voice fixed factor of 3 up and down sampling functions do
     not crash with a LOAD_STORE exception.
   * ADDED: Missing device attributes to the .xn file of the AN00231 app note.
+  * ADDED: Minimal cmake support.
 
 2.1.0
 -----

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.21.0)
+project(lib_src LANGUAGES C ASM)
+
+if(PROJECT_IS_TOP_LEVEL)
+    include(FetchContent)
+    FetchContent_Declare(
+      fwk_core
+      GIT_REPOSITORY https://github.com/xmos/fwk_core.git
+      GIT_TAG        v1.0.0
+    )
+    FetchContent_MakeAvailable(fwk_core)
+endif()
+
+if((${CMAKE_SYSTEM_PROCESSOR} STREQUAL XCORE_XS3A) OR (${CMAKE_SYSTEM_PROCESSOR} STREQUAL XCORE_XS2A))
+    ## Source files
+    file(GLOB_RECURSE LIB_C_SOURCES   lib_src/src/*.c )
+    file(GLOB_RECURSE LIB_XC_SOURCES  lib_src/src/*.xc)
+    file(GLOB_RECURSE LIB_ASM_SOURCES lib_src/src/*.S )
+
+    ## Create library target
+    add_library(lib_src STATIC EXCLUDE_FROM_ALL ${LIB_C_SOURCES} ${LIB_ASM_SOURCES} ${LIB_XC_SOURCES})
+    target_include_directories(lib_src
+        PUBLIC
+            lib_src/api
+            lib_src/src/fixed_factor_of_3
+            lib_src/src/fixed_factor_of_3/ds3
+            lib_src/src/fixed_factor_of_3/os3
+            lib_src/src/fixed_factor_of_3_voice
+            lib_src/src/fixed_factor_of_3_voice/ds3_voice
+            lib_src/src/fixed_factor_of_3_voice/us3_voice
+            lib_src/src/multirate_hifi
+            lib_src/src/multirate_hifi/asrc
+            lib_src/src/multirate_hifi/ssrc
+    )
+    target_link_libraries(lib_src
+        PUBLIC
+            # defined in fwk_core
+            framework_core_legacy_compat
+    )
+    target_compile_options(lib_src
+        PRIVATE 
+            -O3
+    )
+
+endif()


### PR DESCRIPTION
This PR implements the same level of cmake support that is currently being manually written in each project that is using it.

Therefore it does not include the below however previous build is still present so this PR does not remove these things:

- building examples/tests with cmake
- Any build flags which are not being used in sln_voice or otherwise

Merging this PR will allow downstream projects to use this project without code duplication. I have tested that this works with my project. 

closes #62 