### PR TITLE
Release/v2.2.0

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,0 @@
-tap 'homebrew/core'
-
-brew 'perl'
-brew 'cpanm'
-
-brew 'python@2'
-brew 'pipenv'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 lib_src change log
 ==================
 
+2.2.0
+-----
+
+  * CHANGED: Made the FIR coefficient array that is used with the voice fixed
+    factor of 3 up and down sampling functions usable from within C files as
+    well as XC files.
+  * CHANGED: Aligned the FIR coefficient array to an 8-byte boundary. This
+    ensures that the voice fixed factor of 3 up and down sampling functions do
+    not crash with a LOAD_STORE exception.
+  * ADDED: Missing device attributes to the .xn file of the AN00231 app note.
+
 2.1.0
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,12 @@ lib_src change log
     not crash with a LOAD_STORE exception.
   * ADDED: Missing device attributes to the .xn file of the AN00231 app note.
 
+  * Changes to dependencies:
+
+    - lib_logging: 2.0.1 -> 3.1.1
+
+    - lib_xassert: 2.0.1 -> 4.1.0
+
 2.1.0
 -----
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,14 @@
-@Library('xmos_jenkins_shared_library@v0.16.2') _
+@Library('xmos_jenkins_shared_library@v0.18.0') _
 
 getApproval()
 
 pipeline {
   agent {
-    label 'x86_64&&brew&&macOS'
+    label 'x86_64&&macOS'
   }
   environment {
     REPO = 'lib_src'
-    VIEW = "${env.JOB_NAME.contains('PR-') ? REPO+'_'+env.CHANGE_TARGET : REPO+'_'+env.BRANCH_NAME}"
+    VIEW = getViewName(REPO)
   }
   options {
     skipDefaultCheckout()

--- a/examples/AN00231_ASRC_SPDIF_TO_DAC/src/xk-audio-216-mc.xn
+++ b/examples/AN00231_ASRC_SPDIF_TO_DAC/src/xk-audio-216-mc.xn
@@ -83,10 +83,12 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
-      <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
-      <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
+      <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK"/>
+      <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO"/>
+      <Attribute Name="QE_REGISTER" Value="flash_qe_location_status_reg_0"/>
+      <Attribute Name="QE_BIT" Value="flash_qe_bit_6"/>
     </Device>
   </ExternalDevices>
   <JTAGChain>

--- a/lib_src/module_build_info
+++ b/lib_src/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 2.1.0
+VERSION = 2.2.0
 
 DEPENDENT_MODULES = lib_logging(>=3.0.0) \
                     lib_xassert(>=4.0.0)

--- a/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.h
+++ b/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.h
@@ -21,6 +21,13 @@ extern const unsigned src_ff3v_fir_comp_q_us;
 extern const int32_t src_ff3v_fir_comp_us;
 
 extern int32_t src_ff3v_fir_coefs_debug[SRC_FF3V_FIR_NUM_PHASES * SRC_FF3V_FIR_TAPS_PER_PHASE];
-extern const int32_t src_ff3v_fir_coefs[SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_PHASE];
+
+#if defined(__XC__)
+extern const int32_t (*src_ff3v_fir_coefs_xc)[SRC_FF3V_FIR_TAPS_PER_PHASE];
+#define src_ff3v_fir_coefs src_ff3v_fir_coefs_xc
+#else
+extern const int32_t (*src_ff3v_fir_coefs_c)[SRC_FF3V_FIR_TAPS_PER_PHASE];
+#define src_ff3v_fir_coefs src_ff3v_fir_coefs_c
+#endif
 
 #endif // _SRC_FF3V_FIR_H_

--- a/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.xc
+++ b/lib_src/src/fixed_factor_of_3_voice/src_ff3v_fir.xc
@@ -39,7 +39,7 @@ int32_t src_ff3v_fir_coefs_debug[SRC_FF3V_FIR_NUM_PHASES * SRC_FF3V_FIR_TAPS_PER
 };
 
 /** Coefficients for use with src_ds3_voice and src_us3_voice functions */
-const int32_t src_ff3v_fir_coefs[SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_PHASE] = {
+static const int32_t [[aligned(8)]] src_ff3v_fir_coefs_i[SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_PHASE] = {
     {
             29412,    -14619962,      2692812,     -2814524,      2193307,     -1338213,
           -123797,      2582573,     -6837031,     15085431,    -37235961,    320542055,
@@ -59,3 +59,9 @@ const int32_t src_ff3v_fir_coefs[SRC_FF3V_FIR_NUM_PHASES][SRC_FF3V_FIR_TAPS_PER_
          -1338213,      2193307,     -2814524,      2692812,    -14619962,        29412,
     },
 };
+
+unsafe {
+    const int32_t (* unsafe src_ff3v_fir_coefs_c)[SRC_FF3V_FIR_TAPS_PER_PHASE] = src_ff3v_fir_coefs_i;
+}
+
+const int32_t (*src_ff3v_fir_coefs_xc)[SRC_FF3V_FIR_TAPS_PER_PHASE] = src_ff3v_fir_coefs_i;

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@
 # same modules should appear in the setup.py list as given below.
 
 flake8==3.8.3
+# Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
+importlib-metadata==4.13.0
 matplotlib==3.3.1
 
 # Pin numpy to 1.18.5 due to tensorflow v2.1.1 hard pinning it to that version.


### PR DESCRIPTION
Part of #65

  * CHANGED: Made the FIR coefficient array that is used with the voice fixed
    factor of 3 up and down sampling functions usable from within C files as
    well as XC files.
  * CHANGED: Aligned the FIR coefficient array to an 8-byte boundary. This
    ensures that the voice fixed factor of 3 up and down sampling functions do
    not crash with a LOAD_STORE exception.
  * ADDED: Missing device attributes to the .xn file of the AN00231 app note.