### PR TITLE
Properly annotate function pointers so stack usage is properly calculated for multiple instances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ lib_src change log
   * FIXED: Function pointer annotation avoid stack corruption when using
     multiple instances of SSRC or ASRC.
 
+  * Changes to dependencies:
+
+    - lib_logging: Removed dependency
+    
+    - lib_xassert: Removed dependency
+
 2.4.0
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,12 @@
 lib_src change log
 ==================
 
-UNRELEASED
-----------
+2.5.0
+-----
 
-  * ADDED:     Support for XCommon CMake build system
-  * FIXED:     Function pointer annotation avoid stack corruption when
-               using multiple instances of SSRC or ASRC.
+  * ADDED: Support for XCommon CMake build system
+  * FIXED: Function pointer annotation avoid stack corruption when using
+    multiple instances of SSRC or ASRC.
 
 2.4.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ lib_src change log
   * Changes to dependencies:
 
     - lib_logging: Removed dependency
-    
+
     - lib_xassert: Removed dependency
 
 2.4.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ UNRELEASED
 ----------
 
   * ADDED:     Support for XCommon CMake build system
+  * FIXED:     Function pointer annotation avoid stack corruption when
+               using multiple instances of SSRC or ASRC.
 
 2.4.0
 -----

--- a/lib_src/lib_build_info.cmake
+++ b/lib_src/lib_build_info.cmake
@@ -1,5 +1,5 @@
 set(LIB_NAME lib_src)
-set(LIB_VERSION 2.4.0)
+set(LIB_VERSION 2.5.0)
 
 set(LIB_DEPENDENT_MODULES "lib_logging"
                           "lib_xassert")

--- a/lib_src/module_build_info
+++ b/lib_src/module_build_info
@@ -21,3 +21,12 @@ EXPORT_INCLUDE_DIRS = api \
 
 INCLUDE_DIRS = $(EXPORT_INCLUDE_DIRS)
 
+SOURCE_DIRS = src/fixed_factor_of_3 \
+              src/fixed_factor_of_3/ds3 \
+              src/fixed_factor_of_3/os3 \
+              src/fixed_factor_of_3_voice \
+              src/fixed_factor_of_3_voice/ds3_voice \
+              src/fixed_factor_of_3_voice/us3_voice \
+              src/multirate_hifi \
+              src/multirate_hifi/asrc \
+              src/multirate_hifi/ssrc

--- a/lib_src/module_build_info
+++ b/lib_src/module_build_info
@@ -21,12 +21,3 @@ EXPORT_INCLUDE_DIRS = api \
 
 INCLUDE_DIRS = $(EXPORT_INCLUDE_DIRS)
 
-SOURCE_DIRS = src/fixed_factor_of_3 \
-              src/fixed_factor_of_3/ds3 \
-              src/fixed_factor_of_3/os3 \
-              src/fixed_factor_of_3_voice \
-              src/fixed_factor_of_3_voice/ds3_voice \
-              src/fixed_factor_of_3_voice/us3_voice \
-              src/multirate_hifi \
-              src/multirate_hifi/asrc \
-              src/multirate_hifi/ssrc

--- a/lib_src/module_build_info
+++ b/lib_src/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 2.4.0
+VERSION = 2.5.0
 
 DEPENDENT_MODULES = lib_logging(>=3.1.1) \
                     lib_xassert(>=4.1.0)

--- a/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
+++ b/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
@@ -469,6 +469,7 @@ ASRCReturnCodes_t                ASRC_sync(asrc_ctrl_t* pasrc_ctrl)
 }
 
 
+
 // ==================================================================== //
 // Function:        ASRC_proc_F1_F2                                        //
 // Arguments:        asrc_ctrl_t     *pasrc_ctrl: Ctrl strct.                //
@@ -486,15 +487,19 @@ ASRCReturnCodes_t                ASRC_proc_F1_F2(asrc_ctrl_t* pasrc_ctrl)
     pasrc_ctrl->sFIRF1Ctrl.piIn            = pasrc_ctrl->piIn;
 
     // F1 is always enabled, so call F1
-    if(pasrc_ctrl->sFIRF1Ctrl.pvProc((int *)&pasrc_ctrl->sFIRF1Ctrl) != FIR_NO_ERROR)
-        return ASRC_ERROR; //Notice blatant cast to int * - works around no FP support in XC
+    __attribute__((fptrgroup("G1")))
+    FIRReturnCodes_t ret = pasrc_ctrl->sFIRF1Ctrl.pvProc((int *)&pasrc_ctrl->sFIRF1Ctrl);
+    if(ret != FIR_NO_ERROR)
+        return ASRC_ERROR; 
 
     // Check if F2 is enabled
     if(pasrc_ctrl->sFIRF2Ctrl.eEnable == FIR_ON)
     {
         // F2 is enabled, so call F2
-        if(pasrc_ctrl->sFIRF2Ctrl.pvProc((int *)&pasrc_ctrl->sFIRF2Ctrl) != FIR_NO_ERROR)
-            return ASRC_ERROR;  //Notice blatant cast to int * - works around no FP support in XC
+        __attribute__((fptrgroup("G1")))
+        FIRReturnCodes_t ret = pasrc_ctrl->sFIRF2Ctrl.pvProc((int *)&pasrc_ctrl->sFIRF2Ctrl);
+        if(ret != FIR_NO_ERROR)
+            return ASRC_ERROR; 
 
     }
 

--- a/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
+++ b/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 XMOS LIMITED.
+// Copyright 2016-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // ===========================================================================
 // ===========================================================================

--- a/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
+++ b/lib_src/src/multirate_hifi/asrc/src_mrhf_asrc.c
@@ -487,7 +487,7 @@ ASRCReturnCodes_t                ASRC_proc_F1_F2(asrc_ctrl_t* pasrc_ctrl)
     pasrc_ctrl->sFIRF1Ctrl.piIn            = pasrc_ctrl->piIn;
 
     // F1 is always enabled, so call F1
-    __attribute__((fptrgroup("G1")))
+    __attribute__((fptrgroup("MRHF_G1")))
     FIRReturnCodes_t ret = pasrc_ctrl->sFIRF1Ctrl.pvProc((int *)&pasrc_ctrl->sFIRF1Ctrl);
     if(ret != FIR_NO_ERROR)
         return ASRC_ERROR; 
@@ -496,7 +496,7 @@ ASRCReturnCodes_t                ASRC_proc_F1_F2(asrc_ctrl_t* pasrc_ctrl)
     if(pasrc_ctrl->sFIRF2Ctrl.eEnable == FIR_ON)
     {
         // F2 is enabled, so call F2
-        __attribute__((fptrgroup("G1")))
+        __attribute__((fptrgroup("MRHF_G1")))
         FIRReturnCodes_t ret = pasrc_ctrl->sFIRF2Ctrl.pvProc((int *)&pasrc_ctrl->sFIRF2Ctrl);
         if(ret != FIR_NO_ERROR)
             return ASRC_ERROR; 

--- a/lib_src/src/multirate_hifi/src_mrhf_fir.c
+++ b/lib_src/src/multirate_hifi/src_mrhf_fir.c
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 XMOS LIMITED.
+// Copyright 2016-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // ===========================================================================
 // ===========================================================================

--- a/lib_src/src/multirate_hifi/src_mrhf_fir.c
+++ b/lib_src/src/multirate_hifi/src_mrhf_fir.c
@@ -204,7 +204,7 @@ FIRReturnCodes_t                FIR_sync(FIRCtrl_t* psFIRCtrl)
 //                    FIR_ERROR on failure                                //
 // Description:        Processes the FIR in over-sample by 2 mode            //
 // ==================================================================== //
- __attribute__((fptrgroup("G1")))
+ __attribute__((fptrgroup("MRHF_G1")))
 FIRReturnCodes_t                FIR_proc_os2(FIRCtrl_t* psFIRCtrl)
 {
     int*            piIn        = psFIRCtrl->piIn;
@@ -296,7 +296,7 @@ FIRReturnCodes_t                FIR_proc_os2(FIRCtrl_t* psFIRCtrl)
 //                    FIR_ERROR on failure                                //
 // Description:        Processes the FIR in asynchronous mode                //
 // ==================================================================== //
-__attribute__((fptrgroup("G1")))
+__attribute__((fptrgroup("MRHF_G1")))
 FIRReturnCodes_t                FIR_proc_sync(FIRCtrl_t* psFIRCtrl)
 {
     int*            piIn        = psFIRCtrl->piIn;
@@ -353,7 +353,7 @@ FIRReturnCodes_t                FIR_proc_sync(FIRCtrl_t* psFIRCtrl)
 //                    FIR_ERROR on failure                                //
 // Description:        Processes the FIR in down-sample by 2 mode            //
 // ==================================================================== //
-__attribute__((fptrgroup("G1")))
+__attribute__((fptrgroup("MRHF_G1")))
 FIRReturnCodes_t                FIR_proc_ds2(FIRCtrl_t* psFIRCtrl)
 {
     int*            piIn        = psFIRCtrl->piIn;

--- a/lib_src/src/multirate_hifi/src_mrhf_fir.c
+++ b/lib_src/src/multirate_hifi/src_mrhf_fir.c
@@ -204,6 +204,7 @@ FIRReturnCodes_t                FIR_sync(FIRCtrl_t* psFIRCtrl)
 //                    FIR_ERROR on failure                                //
 // Description:        Processes the FIR in over-sample by 2 mode            //
 // ==================================================================== //
+ __attribute__((fptrgroup("G1")))
 FIRReturnCodes_t                FIR_proc_os2(FIRCtrl_t* psFIRCtrl)
 {
     int*            piIn        = psFIRCtrl->piIn;
@@ -295,6 +296,7 @@ FIRReturnCodes_t                FIR_proc_os2(FIRCtrl_t* psFIRCtrl)
 //                    FIR_ERROR on failure                                //
 // Description:        Processes the FIR in asynchronous mode                //
 // ==================================================================== //
+__attribute__((fptrgroup("G1")))
 FIRReturnCodes_t                FIR_proc_sync(FIRCtrl_t* psFIRCtrl)
 {
     int*            piIn        = psFIRCtrl->piIn;
@@ -351,6 +353,7 @@ FIRReturnCodes_t                FIR_proc_sync(FIRCtrl_t* psFIRCtrl)
 //                    FIR_ERROR on failure                                //
 // Description:        Processes the FIR in down-sample by 2 mode            //
 // ==================================================================== //
+__attribute__((fptrgroup("G1")))
 FIRReturnCodes_t                FIR_proc_ds2(FIRCtrl_t* psFIRCtrl)
 {
     int*            piIn        = psFIRCtrl->piIn;

--- a/lib_src/src/multirate_hifi/src_mrhf_fir.h
+++ b/lib_src/src/multirate_hifi/src_mrhf_fir.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 XMOS LIMITED.
+// Copyright 2016-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // ===========================================================================
 // ===========================================================================

--- a/lib_src/src/multirate_hifi/src_mrhf_fir.h
+++ b/lib_src/src/multirate_hifi/src_mrhf_fir.h
@@ -211,7 +211,7 @@
             unsigned int                            uiNOutSamples;    // Number of output samples produced
             unsigned int                            uiOutStep;        // Step between output data samples
 
-__attribute__((fptrgroup("G1")))
+__attribute__((fptrgroup("MRHF_G1")))
             FIRReturnCodes_t                         (*pvProc)(int *);// Processing function address
 
             int*                                    piDelayB;        // Pointer to delay line base

--- a/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
+++ b/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2016-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // ===========================================================================
 // ===========================================================================

--- a/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
+++ b/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
@@ -393,16 +393,20 @@ SSRCReturnCodes_t                SSRC_proc_F1_F2(ssrc_ctrl_t* pssrc_ctrl)
     }
 
     // F1 is enabled, so call F1
-    if(pssrc_ctrl->sFIRF1Ctrl.pvProc((int *)&pssrc_ctrl->sFIRF1Ctrl) != FIR_NO_ERROR)
-        return SSRC_ERROR; //Note blatant cast to int * to work around no FP support in XC
+    __attribute__((fptrgroup("G1")))
+    FIRReturnCodes_t ret = pssrc_ctrl->sFIRF1Ctrl.pvProc((int *)&pssrc_ctrl->sFIRF1Ctrl);
+    if(ret != FIR_NO_ERROR)
+        return SSRC_ERROR;
 
 
     // Check if F2 is enabled
     if(pssrc_ctrl->sFIRF2Ctrl.eEnable == FIR_ON)
     {
         // F2 is enabled, so call F2
-        if(pssrc_ctrl->sFIRF2Ctrl.pvProc((int *)&pssrc_ctrl->sFIRF2Ctrl) != FIR_NO_ERROR)
-            return SSRC_ERROR; //Note blatant cast to int * to work around no FP support in XC
+        __attribute__((fptrgroup("G1")))
+        FIRReturnCodes_t ret = pssrc_ctrl->sFIRF2Ctrl.pvProc((int *)&pssrc_ctrl->sFIRF2Ctrl);
+        if(ret != FIR_NO_ERROR)
+            return SSRC_ERROR;
     }
 
     return SSRC_NO_ERROR;

--- a/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
+++ b/lib_src/src/multirate_hifi/ssrc/src_mrhf_ssrc.c
@@ -393,7 +393,7 @@ SSRCReturnCodes_t                SSRC_proc_F1_F2(ssrc_ctrl_t* pssrc_ctrl)
     }
 
     // F1 is enabled, so call F1
-    __attribute__((fptrgroup("G1")))
+    __attribute__((fptrgroup("MRHF_G1")))
     FIRReturnCodes_t ret = pssrc_ctrl->sFIRF1Ctrl.pvProc((int *)&pssrc_ctrl->sFIRF1Ctrl);
     if(ret != FIR_NO_ERROR)
         return SSRC_ERROR;
@@ -403,7 +403,7 @@ SSRCReturnCodes_t                SSRC_proc_F1_F2(ssrc_ctrl_t* pssrc_ctrl)
     if(pssrc_ctrl->sFIRF2Ctrl.eEnable == FIR_ON)
     {
         // F2 is enabled, so call F2
-        __attribute__((fptrgroup("G1")))
+        __attribute__((fptrgroup("MRHF_G1")))
         FIRReturnCodes_t ret = pssrc_ctrl->sFIRF2Ctrl.pvProc((int *)&pssrc_ctrl->sFIRF2Ctrl);
         if(ret != FIR_NO_ERROR)
             return SSRC_ERROR;

--- a/settings.yml
+++ b/settings.yml
@@ -1,7 +1,7 @@
 ---
 project: lib_src
 title: SAMPLE RATE CONVERSION
-version: 2.4.0
+version: 2.5.0
 
 documentation:
   exclude_patterns_path: doc/exclude_patterns.inc


### PR DESCRIPTION
Looks like fptr groups were not fully implemented, causing stack corruption in my ASRC implementation which uses multiple threads. 
Also, the head of develop didn't pass lib tests so fixed that too. I have temporarily given this version 2.5.0 since there is a fix (patch) plus a new feature (minor)