### PR TITLE
Remove unused dependency lib_xassert

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ lib_src change log
 
     - lib_logging: 3.1.1 -> 3.2.0
 
-    - lib_xassert: 4.1.0 -> 4.2.0
+    - lib_xassert: Removed dependency
 
 2.4.0
 -----

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,6 @@ pipeline {
               sh 'git clone git@github.com:xmos/infr_scripts_py.git'
               // These are needed for xmake legacy build and also changelog check
               sh 'git clone git@github.com:xmos/lib_logging.git'
-              sh 'git clone git@github.com:xmos/lib_xassert.git'
               withVenv {
                 sh 'pip install -e infr_scripts_py'
                 sh 'pip install -e infr_apps'

--- a/lib_src/lib_build_info.cmake
+++ b/lib_src/lib_build_info.cmake
@@ -1,8 +1,7 @@
 set(LIB_NAME lib_src)
 set(LIB_VERSION 2.5.0)
 
-set(LIB_DEPENDENT_MODULES "lib_logging"
-                          "lib_xassert")
+set(LIB_DEPENDENT_MODULES "lib_logging(3.2.0)")
 
 set(LIB_COMPILER_FLAGS -Wno-missing-braces -O3)
 

--- a/lib_src/module_build_info
+++ b/lib_src/module_build_info
@@ -1,7 +1,6 @@
 VERSION = 2.5.0
 
-DEPENDENT_MODULES = lib_logging(>=3.1.1) \
-                    lib_xassert(>=4.1.0)
+DEPENDENT_MODULES = lib_logging(>=3.2.0)
 
 MODULE_XCC_FLAGS = $(XCC_FLAGS) \
                    -Wno-missing-braces \


### PR DESCRIPTION
lib_xassert isn't used by any library code in lib_src, so removing it. Also pinned lib_logging to the latest released tag now that it supports xcommon_cmake.