### PR TITLE
Return code on asynchronous_fifo_consumer_get

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,6 @@
 lib_src change log
 ==================
 
-
 UNRELEASED
 ----------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
   * ADDED: Return code on asynchronous_fifo_consumer_get() to indicate if 
     samples are valid or not
+  * ADDED: ASRC task clears pulled samples to zero if FIFO is not valid
 
 2.5.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 lib_src change log
 ==================
 
+
+UNRELEASED
+----------
+
+  * ADDED: Return code on asynchronous_fifo_consumer_get() to indicate if 
+    samples are valid or not
+
 2.5.0
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ UNRELEASED
 
   * ADDED: Return code on asynchronous_fifo_consumer_get() to indicate if 
     samples are valid or not
-  * ADDED: ASRC task clears pulled samples to zero if FIFO is not valid
+  * CHANGED: ASRC task zeros pulled samples if FIFO get is not valid
 
 2.5.0
 -----

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.25.0')
+@Library('xmos_jenkins_shared_library@v0.29.0')
 
 def runningOn(machine) {
     println "Stage running on:"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.29.0')
+@Library('xmos_jenkins_shared_library@v0.33.0')
 
 def runningOn(machine) {
     println "Stage running on:"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,8 +210,8 @@ pipeline {
               steps {
                 runningOn(env.NODE_NAME)
                 dir("${REPO}") {
-                  sh 'git clone git@github.com:xmos/infr_apps.git'
-                  sh 'git clone git@github.com:xmos/infr_scripts_py.git'
+                  sh 'git clone --branch master git@github.com:xmos/infr_apps.git'
+                  sh 'git clone --branch master git@github.com:xmos/infr_scripts_py.git'
                   // These are needed for xmake legacy build and also changelog check
                   sh 'git clone git@github.com:xmos/lib_logging.git'
                   withVenv {

--- a/doc/asynchronous_fifo/asynchronous_fifo.rst
+++ b/doc/asynchronous_fifo/asynchronous_fifo.rst
@@ -84,7 +84,7 @@ The Asynchronous FIFO has the following functions to control the FIFO:
 
 * ``asynchronous_fifo_consumer_get()`` gets one sample from the FIFO. It
   must be given a timestamp related to when this (or the previous) sample
-  is (was) output.
+  is (was) output. It returns 1 if the pulled samples are valid else zero.
 
 All timestamps are measured in 100 MHz ticks.
 

--- a/lib_src/api/asynchronous_fifo.h
+++ b/lib_src/api/asynchronous_fifo.h
@@ -195,6 +195,16 @@ int32_t asynchronous_fifo_producer_put(asynchronous_fifo_t * UNSAFE state,
 
 
 /**
+ * Return code for asynchronous_fifo_consumer_get()
+ */
+typedef enum asynchronous_fifo_get_return_t_ {
+    ASYNCH_FIFO_OK = 0,
+    ASYNCH_FIFO_UNDERFLOW,
+    ASYNCH_FIFO_IN_RESET
+} asynchronous_fifo_get_return_t;
+
+
+/**
  * Function that gets an output sample from the asynchronous FIFO
  *
  * @param   state               ASRC structure to read a sample out off.
@@ -206,13 +216,12 @@ int32_t asynchronous_fifo_producer_put(asynchronous_fifo_t * UNSAFE state,
  *                              last sample was output. See
  *                              ``asynchronous_fifo_produce`` for requirements.
  * 
- * @returns One if the samples are valid or zero if the FIFO is in reset following
- *          initilaisation, underflow or overflow. 
+ * @returns The FIFO status and whether the samples are valid or not
 
  */
-int asynchronous_fifo_consumer_get(asynchronous_fifo_t * UNSAFE state,
-                                   int32_t * UNSAFE samples,
-                                   int32_t timestamp);
+asynchronous_fifo_get_return_t asynchronous_fifo_consumer_get(asynchronous_fifo_t * UNSAFE state,
+                                                                int32_t * UNSAFE samples,
+                                                                int32_t timestamp);
 
 
 /**

--- a/lib_src/api/asynchronous_fifo.h
+++ b/lib_src/api/asynchronous_fifo.h
@@ -205,10 +205,14 @@ int32_t asynchronous_fifo_producer_put(asynchronous_fifo_t * UNSAFE state,
  * @param   timestamp           A timestamp taken at the time that the
  *                              last sample was output. See
  *                              ``asynchronous_fifo_produce`` for requirements.
+ * 
+ * @returns One if the samples are valid or zero if the FIFO is in reset following
+ *          initilaisation, underflow or overflow. 
+
  */
-void asynchronous_fifo_consumer_get(asynchronous_fifo_t * UNSAFE state,
-                                    int32_t * UNSAFE samples,
-                                    int32_t timestamp);
+int asynchronous_fifo_consumer_get(asynchronous_fifo_t * UNSAFE state,
+                                   int32_t * UNSAFE samples,
+                                   int32_t timestamp);
 
 
 /**

--- a/lib_src/src/asrc_task/asrc_task.c
+++ b/lib_src/src/asrc_task/asrc_task.c
@@ -359,7 +359,6 @@ DEFINE_INTERRUPT_PERMITTED(ASRC_ISR_GRP, void, asrc_processor,
                 sASRCCtrl[instance][ch].piADCoefs                 = asrc_adfir_coefs[instance].iASRCADFIRCoefs;
             }
             fs_ratio = asrc_init(inputFsCode, outputFsCode, sASRCCtrl[instance], max_channels_per_instance, SRC_N_IN_SAMPLES, SRC_DITHER_SETTING);
-            dprintf("ASRC init instance: %d ptr: %p\n", instance, sASRCCtrl[instance]);
         }
 
         //// Timing check vars. Includes ASRC, timestamp interpolation and FIFO push
@@ -368,7 +367,6 @@ DEFINE_INTERRUPT_PERMITTED(ASRC_ISR_GRP, void, asrc_processor,
         int32_t asrc_peak_processing_time = 0;
 
         ideal_fs_ratio = (fs_ratio + (1<<31)) >> 32;
-        dprintf("ideal_fs_ratio: %d\n", ideal_fs_ratio);
 
         asrc_io->ready_flag_to_receive = 1; // Signal we are ready to consume a frame of input samples
         asrc_io->ready_flag_configured = 1; // SIgnal we are ready to produce
@@ -399,6 +397,7 @@ DEFINE_INTERRUPT_PERMITTED(ASRC_ISR_GRP, void, asrc_processor,
             if(t1 - t0 > asrc_peak_processing_time){
                 asrc_peak_processing_time = t1 - t0;
                 #ifdef DEBUG_ASRC_TASK
+                // Use light-weight printintln instead of printf
                 printintln(asrc_peak_processing_time);
                 #endif
                 // xassert(asrc_peak_processing_time <= asrc_process_time_limit); // Optional assert on timing failure.

--- a/lib_src/src/asrc_task/asrc_task.c
+++ b/lib_src/src/asrc_task/asrc_task.c
@@ -180,7 +180,7 @@ int pull_samples(asrc_in_out_t * asrc_io, asynchronous_fifo_t * fifo, int32_t *s
     asrc_io->output_frequency = output_frequency;
     if (asrc_io->ready_flag_configured){
         // Zero samples if got samples are invalid
-        if(asynchronous_fifo_consumer_get(fifo, samples, consume_timestamp) == 0){
+        if(asynchronous_fifo_consumer_get(fifo, samples, consume_timestamp) != ASYNCH_FIFO_OK){
             memset(samples, 0, fifo->channel_count * sizeof(samples[0]));
         }
         return asrc_io->asrc_channel_count;

--- a/lib_src/src/asrc_task/asrc_task.c
+++ b/lib_src/src/asrc_task/asrc_task.c
@@ -179,7 +179,10 @@ int par_asrc(int num_jobs, schedule_info_t schedule[], uint64_t fs_ratio, asrc_i
 int pull_samples(asrc_in_out_t * asrc_io, asynchronous_fifo_t * fifo, int32_t *samples, uint32_t output_frequency, int32_t consume_timestamp){
     asrc_io->output_frequency = output_frequency;
     if (asrc_io->ready_flag_configured){
-        asynchronous_fifo_consumer_get(fifo, samples, consume_timestamp);
+        // Zero samples if got samples are invalid
+        if(asynchronous_fifo_consumer_get(fifo, samples, consume_timestamp) == 0){
+            memset(samples, 0, fifo->channel_count * sizeof(samples[0]));
+        }
         return asrc_io->asrc_channel_count;
     }
     return 0;

--- a/lib_src/src/asynchronous_fifo.c
+++ b/lib_src/src/asynchronous_fifo.c
@@ -209,7 +209,7 @@ int asynchronous_fifo_consumer_get(asynchronous_fifo_t *state, int32_t *samples,
         state->timestamps[read_ptr] = timestamp;
         return 1;
     } else {
-        state->reset = 1;                // The rest must happen in the other thread
+        state->reset = 1;                // The reset must happen in the other thread
     }
     return 0;
 }

--- a/lib_src/src/asynchronous_fifo.c
+++ b/lib_src/src/asynchronous_fifo.c
@@ -184,7 +184,7 @@ int32_t asynchronous_fifo_producer_put(asynchronous_fifo_t *state, int32_t *samp
  * the producer fails. The producer side is reset exactly once on reset.
  * If this is a problem then please use the return flag (0 = OK) to handle.
  */
-int asynchronous_fifo_consumer_get(asynchronous_fifo_t *state, int32_t *samples, int32_t timestamp) {
+asynchronous_fifo_get_return_t asynchronous_fifo_consumer_get(asynchronous_fifo_t *state, int32_t *samples, int32_t timestamp) {
     int read_ptr = state->read_ptr;
     int write_ptr = state->write_ptr;
     int max_fifo_depth = state->max_fifo_depth;
@@ -200,16 +200,16 @@ int asynchronous_fifo_consumer_get(asynchronous_fifo_t *state, int32_t *samples,
     asm("vstrpv %0[0], %1" :: "r" (samples), "r" (copy_mask));
 #endif
     if (state->reset) {
-        return 0;
+        return ASYNCH_FIFO_IN_RESET;
     }
     if (len > 2) {
         // TODO: use IF not %
         read_ptr = (read_ptr + 1) % state->max_fifo_depth;
         state->read_ptr = read_ptr;
         state->timestamps[read_ptr] = timestamp;
-        return 1;
+        return ASYNCH_FIFO_OK;
     } else {
         state->reset = 1;                // The reset must happen in the other thread
     }
-    return 0;
+    return ASYNCH_FIFO_UNDERFLOW;
 }

--- a/tests/test_lib_checks.py
+++ b/tests/test_lib_checks.py
@@ -5,6 +5,7 @@ from subprocess import run
 from pathlib import Path
 import json
 import re
+import sys
 
 REPO_ROOT = (Path(__file__).parent/"..").resolve()
 
@@ -40,5 +41,9 @@ def test_version_matches():
         with open(Path(__file__).resolve().parent / "../CHANGELOG.rst") as cl:
             re_string = r"([0-9]*)\.([0-9]*)\.([0-9]*)"
             sy_ver = re.search(re_string, sy.readlines()[3]).groups()
-            cl_ver = re.search(re_string, cl.readlines()[3]).groups()
-            assert sy_ver == cl_ver, f"Version match issue between settings.yml and CHANGELOG.rst: {sy_ver} {cl_ver}"
+            cl_txt = cl.readlines()
+            print(cl_txt[3])
+            if not "UNRELEASED" in cl_txt[3]:
+                cl_ver = re.search(re_string, cl_txt[3]).groups()
+                assert sy_ver == cl_ver, f"Version match issue between settings.yml and CHANGELOG.rst: {sy_ver} {cl_ver}"
+            print(f"WARNING: CHANGELOG at UNRELEASED, settings.yml at {'.'.join(sy_ver)}", file=sys.stderr)

--- a/tests/test_lib_checks.py
+++ b/tests/test_lib_checks.py
@@ -1,4 +1,4 @@
-# Copyright 2023 XMOS LIMITED.
+# Copyright 2023-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 """Tests that check the contents of the files meet our standards"""
 from subprocess import run


### PR DESCRIPTION
In support of https://github.com/xmos/lib_src/issues/132

Also updates ASRC task to clear samples to zero if FIFO is not valid

I have tested this in HW and can confirm 0 samples are sent when FIFO invalid for ASRC task which uses the return code.